### PR TITLE
Fix architecture for x86_64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,6 +39,9 @@ download_release() {
   filename="$2"
   platform="$(uname | tr '[:upper:]' '[:lower:]')"
   arch="$(arch)"
+  if [ $arch == "x86_64" ]; then
+    arch="amd64"
+  fi
   variant="${platform}-${arch}"
 
   url="$GH_REPO/releases/download/v${version}/ec2-instance-selector-${variant}.tar.gz"


### PR DESCRIPTION
## Issue
`arch` for our actions runners is x86_64, but ec2-instance-selector suffixes their release w/ `amd64`

## Summary
Select the correct value for `arch` when installing ec2-instance-selector