### PR TITLE
Fix install for macos-latest runner

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,7 +39,7 @@ download_release() {
   filename="$2"
   platform="$(uname | tr '[:upper:]' '[:lower:]')"
   arch="$(arch)"
-  if [ $arch == "x86_64" ]; then
+  if [ $arch == "x86_64" ] || [ $arch == "i386" ]; then
     arch="amd64"
   fi
   variant="${platform}-${arch}"


### PR DESCRIPTION
### Issue
CI is still failing on the `macos-latest` runner

## Summary
Fix the lingering installation issue for the `macos-latest` runner by selecting the correct architecture.